### PR TITLE
Correct Zelda Wiki's Discord link

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -309,7 +309,7 @@
       "forums": "https://www.zeldawiki.org/Zelda_Wiki:About#Connected_Sites",
       "twitter": "https://twitter.com/#!/zeldawiki",
       "facebook": "https://www.facebook.com/zeldawiki",
-      "discord": "https://discord.gg/zelda"
+      "discord": "https://discord.gg/eJnnvYb"
     }
   },
   "it": {


### PR DESCRIPTION
Really don't know about this one, but it appears that Zelda Wiki uses its own Discord server for Zelda Wiki purposes more than Zelda Universe's Discord server.