### PR TITLE
Slightly different margin

### DIFF
--- a/style.css
+++ b/style.css
@@ -258,7 +258,7 @@ a:visited {
   border: 1px #cecece solid;
   border-radius: 5px 0 0 5px;
   border-right: none;
-  margin-right: -10px;
+  margin: 0 -5px 5px 0;
   padding: 3px 5px 3px 5px;
   text-align: right;
 }


### PR DESCRIPTION
The .box .title elements "touch" the widgets and go out of #content. Reducing the margin by 5px to the right and adding 5px to the bottom seems to fix this.