### PR TITLE
Data file JSONS to use arrays / Creating CWW 2021 page

### DIFF
--- a/_api.php
+++ b/_api.php
@@ -19,6 +19,13 @@ class NiwaDataHelper
 	 * @var object
 	 */
 	protected $affiliates;
+	
+	/**
+	 * JSON object of wiki Cross-Wiki Weekend guides
+	 * 
+	 * @var object
+	 */
+	protected $cww;
 
 	const URL_REPLACE_STRING = "$1";
 
@@ -29,6 +36,9 @@ class NiwaDataHelper
 		);
 		$this->affiliates = json_decode(
 			file_get_contents("data/affiliates.json")
+		);
+		$this->cww = json_decode(
+			file_get_contents("data/cww.json")
 		);
 	}
 
@@ -58,7 +68,7 @@ class NiwaDataHelper
 	}
 
 	/**
-	 * Returns a link for the given Wiki interwiki url and page
+	 * Returns a link for the given wiki's interwiki url and page
 	 * 
 	 * @param string $url Interwiki URL
 	 * @param string $page Wiki page
@@ -91,9 +101,24 @@ class NiwaDataHelper
 	{
 		return "<a class='member-wiki-link' href='{$url}'>{$text}</a>";
 	}
+	
+	/**
+	 * Return all member wikis or if language code given,
+	 * all wikis for that language code.
+	 * 
+	 * @param string $languageCode
+	 * @return object
+	 */
+	public function getCWW($year, $languageCode = null)
+	{
+		if ($languageCode) {
+			return $this->cww->{$year}->{$languageCode};
+		}
+		return $this->cww->{$year};
+	}
 
 	/**
-	 * Generates the html string for Links with error checking for wikis that do not have
+	 * Generates the HTML string for links with error checking for wikis that do not have
 	 * one of the options.
 	 *
 	 * Requires a individual wiki array from the api.

--- a/cross-wiki-weekend-2021.php
+++ b/cross-wiki-weekend-2021.php
@@ -3,12 +3,6 @@ $title = 'Cross-Wiki Weekend 2021';
 include('_header.php');
 ?>
 
-<style>
-    a.special:link {color: #B22222 !important;}
-    a.special:visited {color: #B22222 !important;}
-    a.special:hover {color: #B22222 !important;}
-    a.special:active {color: #B22222 !important;}
-</style>
 <!-- Tabs derived from https://codepen.io/oknoblich/pen/tfjFl -->
 <!--
 Copyright (c) 2017 by Oliver Knoblich (http://codepen.io/oknoblich/pen/tfjFl)
@@ -59,7 +53,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
         <ul>
             <li>The event starts at 00:01 (UTC) on Friday, September 24, and runs until 23:59 (UTC) on Monday, September 27.</li>
-            <li>To participate, contribute to at least one <a class="special" href="http://niwanetwork.org/members.php">NIWA wiki</a> that you have never (or rarely) contributed to.</li>
+            <li>To participate, contribute to at least one <a href="http://niwanetwork.org/members.php">NIWA wiki</a> that you have never (or rarely) contributed to.</li>
             <li>To simplify contribution tracking, participants must have an account on the wiki(s) they are contributing to for a chance to win.</li>
             <li>Each contributor's edits are ranked 1 to 10. The more substantial your contributions are, the higher chance you have of winning the prize!</li>
             <li>Contributions should improve the wiki in some way. More substantial contributions mean more entries into the contest. Try some of the following:
@@ -146,7 +140,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
         <br>
 
-        Event organizers this year were <a class="special" href="https://www.pikminwiki.com/User:Espyo">Espyo</a>, <a class="special" href="https://www.ssbwiki.com/User:Serpent_King">Serpent King</a>, <a class="special" href="https://www.mariocastle.it/wiki/Utente:Stormkyleis">Stormkyleis</a>, <a class="special" href="https://nookipedia.com/wiki/User:SuperHamster">SuperHamster</a>, and <a class="special" href="https://fireemblemwiki.org/wiki/User:Tacopill">tacopill</a>.
+        Event organizers this year were <a href="https://www.pikminwiki.com/User:Espyo">Espyo</a>, <a href="https://www.ssbwiki.com/User:Serpent_King">Serpent King</a>, <a href="https://www.mariocastle.it/wiki/Utente:Stormkyleis">Stormkyleis</a>, <a href="https://nookipedia.com/wiki/User:SuperHamster">SuperHamster</a>, and <a href="https://fireemblemwiki.org/wiki/User:Tacopill">tacopill</a>.
         An extra thanks to everyone who contributed to the event with suggestions and guides.
 
         <br><br>
@@ -189,7 +183,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
         <ul>
             <li>L'evento inizia alle 02:01 ora italiana (00:01 UTC) di venerd&#236; 24 settembre e dura fino alle 01:59 ora italiana di marted&#236; 28 settembre (23:59 UTC di luned&#236; 27 settembre).</li>
-            <li>Per partecipare, contribuite ad almeno un <a class="special" href="http://niwanetwork.org/members.php">wiki di NIWA</a> al quale non avete mai (o raramente) contribuito.</li>
+            <li>Per partecipare, contribuite ad almeno un <a href="http://niwanetwork.org/members.php">wiki di NIWA</a> al quale non avete mai (o raramente) contribuito.</li>
             <li>Per tenere traccia dei vostri contributi pi&#249; facilmente, i partecipanti devono possedere un account nei wiki ai quali contribuiscono per avere una possibilit&#224; di vincere.</li>
             <li>I contributi di ciascun utente riceveranno una valutazione da 1 a 5. Pi&#249; sostanziosi saranno i vostri contributi, pi&#249; possibilit&#224; avrete di vincere!</li>
             <li>I contributi dovrebbero migliorare i wiki in qualche modo. I contributi pi&#249; sostanziosi consentiranno di avere maggiori possibilit&#224; di vittoria. Per esempio, provate a:
@@ -275,7 +269,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
         <br>
 
-        I contatti principali dell'evento sono <a class="special" href="https://www.pikminwiki.com/User:Espyo">Espyo</a>, <a class="special" href="https://www.ssbwiki.com/User:Serpent_King">Serpent King</a>, <a class="special" href="https://www.mariocastle.it/wiki/Utente:Stormkyleis">Stormkyleis</a>, <a class="special" href="https://nookipedia.com/wiki/User:SuperHamster">SuperHamster</a>, e <a class="special" href="https://fireemblemwiki.org/wiki/User:Tacopill">tacopill</a>.
+        I contatti principali dell'evento sono <a href="https://www.pikminwiki.com/User:Espyo">Espyo</a>, <a href="https://www.ssbwiki.com/User:Serpent_King">Serpent King</a>, <a href="https://www.mariocastle.it/wiki/Utente:Stormkyleis">Stormkyleis</a>, <a href="https://nookipedia.com/wiki/User:SuperHamster">SuperHamster</a>, e <a href="https://fireemblemwiki.org/wiki/User:Tacopill">tacopill</a>.
         Un ringraziamento speciale a tutti coloro che hanno contribuito all'organizzazione dell'evento con suggerimenti e guide.
 
         <br><br>

--- a/cross-wiki-weekend-2021.php
+++ b/cross-wiki-weekend-2021.php
@@ -1,0 +1,296 @@
+<?php
+$title = 'Cross-Wiki Weekend 2021';
+include('_header.php');
+?>
+
+<style>
+    a.special:link {color: #B22222 !important;}
+    a.special:visited {color: #B22222 !important;}
+    a.special:hover {color: #B22222 !important;}
+    a.special:active {color: #B22222 !important;}
+</style>
+<!-- Tabs derived from https://codepen.io/oknoblich/pen/tfjFl -->
+<!--
+Copyright (c) 2017 by Oliver Knoblich (http://codepen.io/oknoblich/pen/tfjFl)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+
+<div class="main">
+
+    <h1>Cross-Wiki Weekend 2021</h1>
+
+    <input id='tab1' class='member-tab' type='radio' name='tabs' checked>
+    <label for='tab1'>English</label>
+
+    <input id='tab2' class='member-tab' type='radio' name='tabs'>
+    <label for='tab2'>Italian</label>
+
+    <section class="member-tab-content" id='content1'>
+        To celebrate Nintendo's birthday on September 23<sup>rd</sup>, NIWA is hosting a <b>Cross-Wiki Weekend Event</b>!
+        <br><br>
+        From <b>September 24<sup>th</sup> - 27<sup>th</sup></b>, everyone is invited to constructively edit NIWA wikis that they have never (or infrequently) edited before.
+        Whether it's adding some new content, uploading an image, or adding a reference, we want you to take your experience and love for Nintendo to a new wiki.
+        <br><br>
+        At the end of the event, submit your contributions using the button at the bottom of this page. One random participant will win a <b>$20/€20 Nintendo e-Shop Gift Card</b>!
+        <br><br>
+
+        <h1 id="Goals">Goals</h1>
+
+        Why are we hosting this event? In addition to being a fun way of celebrating Nintendo's birthday, we hope this event...
+        <ul>
+            <li>...exposes editors to new wikis</li>
+            <li>...promotes cooperation between NIWA wikis</li>
+            <li>...provides more support for smaller wikis</li>
+            <li>...creates some new long-term editors</li>
+        </ul>
+
+        <div class="text-center"><img class="margin-auto" src="/images/nintendo_characters.png" alt="Several mainline Nintendo characters, including Mario, Pikachu, Kirby, Samus, Bowser, and Donkey Kong." width="400px"></div>
+
+        <br>
+
+        <h1 id="Rules">Rules</h1>
+
+        Before participating, please take a few moments to review these rules - especially if you want a shot at the prize!
+
+        <ul>
+            <li>The event starts at 00:01 (UTC) on Friday, September 24, and runs until 23:59 (UTC) on Monday, September 27.</li>
+            <li>To participate, contribute to at least one <a class="special" href="http://niwanetwork.org/members.php">NIWA wiki</a> that you have never (or rarely) contributed to.</li>
+            <li>To simplify contribution tracking, participants must have an account on the wiki(s) they are contributing to for a chance to win.</li>
+            <li>Each contributor's edits are ranked 1 to 10. The more substantial your contributions are, the higher chance you have of winning the prize!</li>
+            <li>Contributions should improve the wiki in some way. More substantial contributions mean more entries into the contest. Try some of the following:
+            <ul>
+                <li>Adding new prose to articles.</li>
+                <li>Copy-editing large sections or entire articles.</li>
+                <li>Adding references to verify information.</li>
+                <li>Uploading photos.</li>
+                <li>Creating new articles.</li>
+                <li>Categorizing pages.</li>
+                <li>Adding template documentation.</li>
+            </ul>
+            <li>As long as you make at least one non-minor edit, you're eligible to win the prize.</li>
+            <li>Each wiki is a bit different! Become familiar with the differing guidelines, styling, and policies of each wiki. Reach out to each wiki's help resources if you have any questions.</li>
+            <li>At the end of the event, fill out and submit the participation form below by <b>September 30<sup>th</sup></b> for a chance to win the prize. Even if you don't want the prize, we appreciate you filling the form out for statistical purposes.</li>
+        </ul>
+
+        <br>
+
+        <a name="guide"></a>
+        <h1 id="Editing Guide">Editing Guides</h1>
+
+        Below is a list of participating wikis and links to to-do lists and guides.
+        Some wikis have created guides just for this event, which have been linked in bold.
+        If you're unsure of where to begin, you'll hopefully find these links useful!
+        Take a moment to familiarize yourself with each wiki's rules and customs before diving in.
+
+        <br>
+
+        <h3 class="text-center">English Wikis</h3>
+        <div class="text-center cww-grid">
+            <?php
+            $wikis = $dataHelper->getMemberWikis('en');
+            foreach ($dataHelper->getCWW('2021', 'en') as $cww) {
+                $id = $cww->id;
+                $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
+                echo "
+                    <div>
+                        <a href='{$cww->link}'>
+                            <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
+                            <br />
+                            {$cww->title}
+                        </a>
+                    </div>
+                ";
+            }
+            ?>
+        </div>
+        
+        <h3 class="text-center">Italian Wikis</h3>
+        <div class="text-center cww-grid">
+            <?php
+            $wikis = $dataHelper->getMemberWikis('it');
+            foreach ($dataHelper->getCWW('2021', 'it') as $cww) {
+                $id = $cww->id;
+                $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
+                echo "
+                    <div>
+                        <a href='{$cww->link}'>
+                            <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
+                            <br />
+                            {$cww->title}
+                        </a>
+                    </div>
+                ";
+            }
+            ?>
+        </div>
+
+        <br><br>
+
+        <h1 id="Drawing">Drawing</h1>
+        The winner of the contest is determined by random draw.
+        Each person's contributions are rated on a scale of 1 to 5; the more substantial one's contributions, the greater the chance of winning.
+        Be sure to make some substantive edits for a better shot at the prize!
+
+        <br><br>
+
+        While event organizers are free to participate, they are disallowed from entering the drawing and winning the prize.
+
+        <br><br>
+
+        <hr>
+
+        <br>
+
+        Event organizers this year were <a class="special" href="https://www.pikminwiki.com/User:Espyo">Espyo</a>, <a class="special" href="https://www.ssbwiki.com/User:Serpent_King">Serpent King</a>, <a class="special" href="https://www.mariocastle.it/wiki/Utente:Stormkyleis">Stormkyleis</a>, <a class="special" href="https://nookipedia.com/wiki/User:SuperHamster">SuperHamster</a>, and <a class="special" href="https://fireemblemwiki.org/wiki/User:Tacopill">tacopill</a>.
+        An extra thanks to everyone who contributed to the event with suggestions and guides.
+
+        <br><br>
+
+        <span style="font-size: 70%;">
+            Disclaimer: There is no purchase necessary to win. Participants need only meet the requirements listed in the rules above.
+            In questionable cases, final discretion of eligibility is determined by the host of the event.
+            The prize will be a $20/€20 Nintendo e-Shop Gift Card.
+            If participant is in a country where an e-Shop Gift Card is not usable (region restrictions, no e-Shop support, etc.), another prize of equal value will be coordinated with the winner.
+            Winner is determined by a random drawing after contributions are judged on a 1-5 scale by event organizers. Organizers cannot win the prize.
+        </span>
+    </section>
+
+    <section class="member-tab-content" id='content2'>
+        L'anniversario di Nintendo cadr&#224; il 23 settembre. Per celebrarlo NIWA sta organizzando un <b>Cross-Wiki Weekend</b>!
+        <br><br>
+        Dal <b>24 al 27 settembre</b> siete tutti invitati a modificare costruttivamente almeno un wiki di NIWA al quale non avete mai (o raramente) contribuito.
+        Che si tratti di inserire dei nuovi contenuti, caricare un'immagine o aggiungere un riferimento, ci piacerebbe che portaste la vostra esperienza e la vostra passione su un nuovo wiki.
+        <br><br>
+        Al termine dell'evento, un partecipante sorteggiato casualmente vincer&#224; una <b>Nintendo eShop Card da 20$/20€</b>! Quando l'evento sar&#224; concluso potrete inviare le vostre modifiche tramite il pulsante situato in fondo a questa pagina.
+        <br><br>
+
+        <h1 id="Goals">Obiettivi</h1>
+
+        Perch&#233; stiamo organizzando questo evento? Oltre ad essere un modo divertente per celebrare l'anniversario di Nintendo, ci auguriamo che...
+        <ul>
+            <li>... esponga gli utenti a nuovi wiki</li>
+            <li>... promuova la collaborazione tra wiki di NIWA</li>
+            <li>... fornisca maggiore sostegno per i wiki pi&#249; piccoli</li>
+            <li>... faccia nascere nuovi utenti abituali</li>
+        </ul>
+
+        <div class="text-center"><img class="margin-auto" src="/images/nintendo_characters.png" alt="La cr&#232;me de la cr&#232;me di Nintendo." width="400px"></div>
+
+        <br>
+
+        <h1 id="Rules">Regole</h1>
+
+        Prima di partecipare, chiediamo gentilmente un attimo del vostro tempo per leggere queste regole... Specialmente se volete una possibilit&#224; di vincere il premio!
+
+        <ul>
+            <li>L'evento inizia alle 02:01 ora italiana (00:01 UTC) di venerd&#236; 24 settembre e dura fino alle 01:59 ora italiana di marted&#236; 28 settembre (23:59 UTC di luned&#236; 27 settembre).</li>
+            <li>Per partecipare, contribuite ad almeno un <a class="special" href="http://niwanetwork.org/members.php">wiki di NIWA</a> al quale non avete mai (o raramente) contribuito.</li>
+            <li>Per tenere traccia dei vostri contributi pi&#249; facilmente, i partecipanti devono possedere un account nei wiki ai quali contribuiscono per avere una possibilit&#224; di vincere.</li>
+            <li>I contributi di ciascun utente riceveranno una valutazione da 1 a 5. Pi&#249; sostanziosi saranno i vostri contributi, pi&#249; possibilit&#224; avrete di vincere!</li>
+            <li>I contributi dovrebbero migliorare i wiki in qualche modo. I contributi pi&#249; sostanziosi consentiranno di avere maggiori possibilit&#224; di vittoria. Per esempio, provate a:
+            <ul>
+                <li>Aggiungere testo all'interno delle voci;</li>
+                <li>Effettuare correzioni all'interno di paragrafi lunghi o voci intere;</li>
+                <li>Aggiungere riferimenti per verificare la provenienza delle informazioni;</li>
+                <li>Caricare immagini;</li>
+                <li>Creare nuove voci;</li>
+                <li>Aggiungere le categorie appropriate alle pagine;</li>
+                <li>Aggiungere pi&#249; documentazione in merito ai template.</li>
+            </ul>
+            <li>Purch&#233; apportiate almeno una modifica non minore, sarete idonei ad essere sorteggiati per la vittoria del premio.</li>
+            <li>Ciascun wiki &#232; leggermente differente! Prima di apportare modifiche, familiarizzate con le linee guida, i manuali di stile e le pratiche adottate da ciascun wiki. Per qualsiasi domanda, consultate le pagine di aiuto dei rispettivi wiki.</li>
+            <li>Alla fine dell'evento, compilate e inviate il modulo di partecipazione sottostante entro il <b>30 settembre</b> per avere una possibilit&#224; di vincere il premio. Anche se non doveste volere il premio, apprezzeremmo se compilaste il modulo per fini statistici.</li>
+        </ul>
+
+        <br>
+
+        <h1 id="Editing Guide">Manuali di stile</h1>
+
+        Di seguito trovate una lista dei wiki partecipanti, le rispettive guide e le liste di cose da fare.
+        Alcuni wiki hanno creato delle guide appositamente per questo evento, evidenziate in grassetto.
+        Se non siete sicuri di dove iniziare, ci auguriamo che questi link possano tornarvi utili!
+        Prendete un momento per familiarizzare con le regole e le abitudini di ciascun wiki prima di mettervi al lavoro.
+
+        <br>
+        
+        <h3 class="text-center">Wiki in italiano</h3>
+        <div class="text-center cww-grid">
+            <?php
+            $wikis = $dataHelper->getMemberWikis('it');
+            foreach ($dataHelper->getCWW('2021', 'it') as $cww) {
+                $id = $cww->id;
+                $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
+                echo "
+                    <div>
+                        <a href='{$cww->link}'>
+                            <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
+                            <br />
+                            {$cww->title}
+                        </a>
+                    </div>
+                ";
+            }
+            ?>
+        </div>
+        
+        <h3 class="text-center">Wiki in inglese</h3>
+        <div class="text-center cww-grid">
+            <?php
+            $wikis = $dataHelper->getMemberWikis('en');
+            foreach ($dataHelper->getCWW('2021', 'en') as $cww) {
+                $id = $cww->id;
+                $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
+                echo "
+                    <div>
+                        <a href='{$cww->link}'>
+                            <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
+                            <br />
+                            {$cww->title}
+                        </a>
+                    </div>
+                ";
+            }
+            ?>
+        </div>
+
+        <br><br>
+
+        <h1 id="Drawing">Estrazione del premio</h1>
+        Il vincitore del concorso sar&#224; stabilito con un sorteggio casuale.
+        I contributi di ciascun utente verranno valutati con un punteggio da 1 a 5; pi&#249; sostanziosi saranno i contributi, maggiori saranno le probabilit&#224; di vittoria.
+        Assicuratevi di effettuare delle modifiche sostanziose per avere pi&#249; possibilit&#224; di vincere il premio!
+
+        <br><br>
+
+        Sebbene gli organizzatori dell'evento siano liberi di partecipare, saranno esclusi dal sorteggio e di conseguenza non avranno la possibilit&#224; di vincere il premio.
+
+        <br><br>
+
+        <hr>
+
+        <br>
+
+        I contatti principali dell'evento sono <a class="special" href="https://www.pikminwiki.com/User:Espyo">Espyo</a>, <a class="special" href="https://www.ssbwiki.com/User:Serpent_King">Serpent King</a>, <a class="special" href="https://www.mariocastle.it/wiki/Utente:Stormkyleis">Stormkyleis</a>, <a class="special" href="https://nookipedia.com/wiki/User:SuperHamster">SuperHamster</a>, e <a class="special" href="https://fireemblemwiki.org/wiki/User:Tacopill">tacopill</a>.
+        Un ringraziamento speciale a tutti coloro che hanno contribuito all'organizzazione dell'evento con suggerimenti e guide.
+
+        <br><br>
+
+        <span style="font-size: 70%;">
+            Avvertenze: Non &#232; necessario effettuare alcun acquisto per vincere il premio. &#232; sufficiente che i partecipanti soddisfino i requisiti elencati nelle regole sovrastanti.
+            In casi dubbi, l'idoneit&#224; all'estrazione &#232; a discrezione degli organizzatori dell'evento.
+            La posta in palio &#232; una Nintendo eShop Card da 20$/20€.
+            Se il vincitore dovesse risiedere in un paese nel quale risulta impossibile utilizzare l'eShop Card (per esempio a causa delle restrizioni regionali, eShop non supportato in quella determinata regione, ecc.) verr&#224; contattato per stabilire un premio di pari valore.
+            Il vincitore verr&#224; estratto con un sorteggio casuale dopo che i contributi verranno giudicati su una scala da 1 a 5 dagli organizzatori dell'evento. Gli organizzatori non possono vincere il premio.
+        </span>
+    </section>
+</div>
+
+<?php
+include('_sidebar.php');
+include('_footer.php');
+?>

--- a/cross-wiki-weekend-2021.php
+++ b/cross-wiki-weekend-2021.php
@@ -98,7 +98,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
                 $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
                 echo "
                     <div>
-                        <a href='{$cww->link}'>
+                        <a href='{$dataHelper->getWikiLink($wiki->url, $cww->page)}'>
                             <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
                             <br />
                             {$cww->title}
@@ -118,7 +118,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
                 $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
                 echo "
                     <div>
-                        <a href='{$cww->link}'>
+                        <a href='{$dataHelper->getWikiLink($wiki->url, $cww->page)}'>
                             <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
                             <br />
                             {$cww->title}
@@ -227,7 +227,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
                 $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
                 echo "
                     <div>
-                        <a href='{$cww->link}'>
+                        <a href='{$dataHelper->getWikiLink($wiki->url, $cww->page)}'>
                             <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
                             <br />
                             {$cww->title}
@@ -247,7 +247,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
                 $wiki = $wikis[array_search($id, array_column($wikis, 'id'))];
                 echo "
                     <div>
-                        <a href='{$cww->link}'>
+                        <a href='{$dataHelper->getWikiLink($wiki->url, $cww->page)}'>
                             <img class='margin-auto' src='{$wiki->logo}' alt='{$wiki->title}' width='100' />
                             <br />
                             {$cww->title}

--- a/cross-wiki-weekend-2021.php
+++ b/cross-wiki-weekend-2021.php
@@ -133,7 +133,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
         <h1 id="Drawing">Drawing</h1>
         The winner of the contest is determined by random draw.
-        Each person's contributions are rated on a scale of 1 to 5; the more substantial one's contributions, the greater the chance of winning.
+        Each person's contributions are rated on a scale of 10; the more substantial one's contributions, the greater the chance of winning.
         Be sure to make some substantive edits for a better shot at the prize!
 
         <br><br>

--- a/data/affiliates.json
+++ b/data/affiliates.json
@@ -1,82 +1,92 @@
-{
-    "bulbagarden": {
-        "title": "Bulbagarden",
-        "description": "The ultimate Pokémon portal featuring the latest news, forums, community-driven Pokémon encyclopedia and much more.",
-        "logo": "/images/logos/bulbagarden.png",
-        "url": "https://bulbagarden.net/",
-        "forums": "https://forums.bulbagarden.net/index.php",
-        "twitter": "https://twitter.com/Bulbagarden",
-        "facebook": "https://www.facebook.com/Bulbagarden",
-        "discord": "https://discord.gg/bulbagarden"
-    },
-    "doomwiki": {
-        "title": "Doom Wiki",
-        "description": "The Doom Wiki is an extensive community effort to document everything related to id Software's masterpiece games Doom and Doom II, other games based on the Doom engine, Doom 3, Doom (2016), Doom Eternal, and more.",
-        "logo": "/images/logos/doomwiki.png",
-        "url": "http://doomwiki.org/wiki/Entryway",
-        "twitter": "https://twitter.com/doomwiki"
-    },
-    "halopedia": {
-        "title": "Halopedia",
-        "description": "The Halo encyclopedia and definitive source for Halo information that anyone can edit.",
-        "logo": "/images/logos/halopedia.png",
-        "url": "https://www.halopedia.org/",
-        "facebook": "https://www.facebook.com/HalopediaWiki",
-        "twitter": "https://twitter.com/Halopedia",
-        "discord": "https://discord.gg/W3HK45M"
-    },
-    "jojowiki": {
-        "title": "JoJo's Bizarre Encyclopedia",
-        "description": "JoJo's Bizarre Encyclopedia is a wiki dedicated to JoJo's Bizarre Adventure written and illustrated by Hirohiko Araki.",
-        "logo": "/images/logos/jojo.png",
-        "url": "https://jojowiki.com/JoJo_Wiki",
-        "forums": "https://jojowiki.com/Special:WikiForum",
-        "twitter": "https://twitter.com/jojo_wiki",
-        "discord": "https://discord.gg/9jesgZvgbt"
-    },
-    "khwiki": {
-        "title": "Kingdom Hearts Wiki",
-        "description": "The Kingdom Hearts Wiki is a comprehensive wiki and encyclopedia dedicated to the Kingdom Hearts video game series from Square Enix.",
-        "logo": "/images/logos/khwiki.png",
-        "url": "https://www.khwiki.com",
-        "facebook": "https://www.facebook.com/khwikinet",
-        "chat": "https://www.khwiki.com/KHWiki:Chat",
-        "twitter": "https://twitter.com/KHWiki",
-        "discord": "https://discord.gg/bavMzKu"
-    },
-    "seiwanetwork": {
-        "title": "SEIWA",
-        "description": "The Square Enix Wiki Independent Alliance, or SEIWA for short, is a group of Wiki's centered around Square Enix's many franchises.",
-        "logo": "/images/logos/seiwa.png",
-        "url": "https://seiwanetwork.org/"
-    },
-    "wikifang": {
-        "title": "Wikifang",
-        "description": "Wikifang is an independent wiki on the chain of Smilesoft games, namely the Keitai Denjuu Telefang series, the GachaSta! Dino Device series, and Network Adventure Bugsite.",
-        "logo": "/images/logos/wikifang.png",
-        "url": "https://wiki.telefang.net/Wikifang"
-    },
-    "wikimon": {
-        "title": "Wikimon",
-        "description": "The free Digimon online encyclopedia that anyone can read and help edit. Wikimon is the best resource for Digimon info since December 2005—over fifteen years of pure Digimon goodness!",
-        "logo": "/images/logos/wikimon.png",
-        "url": "http://wikimon.net/",
-        "facebook": "http://www.facebook.com/digiwikimon",
-        "twitter": "http://twitter.com/Wikimon_news"
-    },
-    "simpsonswiki": {
-        "title": "Wikisimpsons",
-        "description": "Wikisimpsons is an encyclopedic wiki that contains information regarding the The Simpsons episodes, comic books and other media, including characters, locations and more.",
-        "logo": "/images/logos/wikisimpsons.png",
-        "url": "https://simpsonswiki.com/wiki/Main_Page",
-        "facebook": "http://www.facebook.com/wikisimpsons",
-        "twitter": "http://twitter.com/simpsonswiki",
-        "discord": "https://discord.gg/GyneDH6"
-    },
-    "zeldachaos": {
-        "title": "Zelda Chaos",
-        "description": "Zelda Chaos is the top resource for all things exploitable in Zelda.",
-        "logo": "/images/logos/zeldachaos.png",
-        "url": "https://jaytheham.com/zcw/Main_Page"
-    }
-}
+[
+  {
+    "id": "bulbagarden",
+    "title": "Bulbagarden",
+    "description": "The ultimate Pokémon portal featuring the latest news, forums, community-driven Pokémon encyclopedia and much more.",
+    "logo": "/images/logos/bulbagarden.png",
+    "url": "https://bulbagarden.net/",
+    "forums": "https://forums.bulbagarden.net/index.php",
+    "twitter": "https://twitter.com/Bulbagarden",
+    "facebook": "https://www.facebook.com/Bulbagarden",
+    "discord": "https://discord.gg/bulbagarden"
+  },
+  {
+    "id": "doomwiki",
+    "title": "Doom Wiki",
+    "description": "The Doom Wiki is an extensive community effort to document everything related to id Software's masterpiece games Doom and Doom II, other games based on the Doom engine, Doom 3, Doom (2016), Doom Eternal, and more.",
+    "logo": "/images/logos/doomwiki.png",
+    "url": "http://doomwiki.org/wiki/Entryway",
+    "twitter": "https://twitter.com/doomwiki"
+  },
+  {
+    "id": "halopedia",
+    "title": "Halopedia",
+    "description": "The Halo encyclopedia and definitive source for Halo information that anyone can edit.",
+    "logo": "/images/logos/halopedia.png",
+    "url": "https://www.halopedia.org/",
+    "facebook": "https://www.facebook.com/HalopediaWiki",
+    "twitter": "https://twitter.com/Halopedia",
+    "discord": "https://discord.gg/W3HK45M"
+  },
+  {
+    "id": "jojowiki",
+    "title": "JoJo's Bizarre Encyclopedia",
+    "description": "JoJo's Bizarre Encyclopedia is a wiki dedicated to JoJo's Bizarre Adventure written and illustrated by Hirohiko Araki.",
+    "logo": "/images/logos/jojo.png",
+    "url": "https://jojowiki.com/JoJo_Wiki",
+    "forums": "https://jojowiki.com/Special:WikiForum",
+    "twitter": "https://twitter.com/jojo_wiki",
+    "discord": "https://discord.gg/9jesgZvgbt"
+  },
+  {
+    "id": "khwiki",
+    "title": "Kingdom Hearts Wiki",
+    "description": "The Kingdom Hearts Wiki is a comprehensive wiki and encyclopedia dedicated to the Kingdom Hearts video game series from Square Enix.",
+    "logo": "/images/logos/khwiki.png",
+    "url": "https://www.khwiki.com",
+    "facebook": "https://www.facebook.com/khwikinet",
+    "chat": "https://www.khwiki.com/KHWiki:Chat",
+    "twitter": "https://twitter.com/KHWiki",
+    "discord": "https://discord.gg/bavMzKu"
+  },
+  {
+    "id": "seiwanetwork",
+    "title": "SEIWA",
+    "description": "The Square Enix Wiki Independent Alliance, or SEIWA for short, is a group of Wiki's centered around Square Enix's many franchises.",
+    "logo": "/images/logos/seiwa.png",
+    "url": "https://seiwanetwork.org/"
+  },
+  {
+    "id": "wikifang",
+    "title": "Wikifang",
+    "description": "Wikifang is an independent wiki on the chain of Smilesoft games, namely the Keitai Denjuu Telefang series, the GachaSta! Dino Device series, and Network Adventure Bugsite.",
+    "logo": "/images/logos/wikifang.png",
+    "url": "https://wiki.telefang.net/Wikifang"
+  },
+  {
+    "id": "wikimon",
+    "title": "Wikimon",
+    "description": "The free Digimon online encyclopedia that anyone can read and help edit. Wikimon is the best resource for Digimon info since December 2005—over fifteen years of pure Digimon goodness!",
+    "logo": "/images/logos/wikimon.png",
+    "url": "http://wikimon.net/",
+    "facebook": "http://www.facebook.com/digiwikimon",
+    "twitter": "http://twitter.com/Wikimon_news"
+  },
+  {
+    "id": "simpsonswiki",
+    "title": "Wikisimpsons",
+    "description": "Wikisimpsons is an encyclopedic wiki that contains information regarding the The Simpsons episodes, comic books and other media, including characters, locations and more.",
+    "logo": "/images/logos/wikisimpsons.png",
+    "url": "https://simpsonswiki.com/wiki/Main_Page",
+    "facebook": "http://www.facebook.com/wikisimpsons",
+    "twitter": "http://twitter.com/simpsonswiki",
+    "discord": "https://discord.gg/GyneDH6"
+  },
+  {
+    "id": "zeldachaos",
+    "title": "Zelda Chaos",
+    "description": "Zelda Chaos is the top resource for all things exploitable in Zelda.",
+    "logo": "/images/logos/zeldachaos.png",
+    "url": "https://jaytheham.com/zcw/Main_Page"
+  }
+]

--- a/data/cww.json
+++ b/data/cww.json
@@ -4,149 +4,149 @@
       {
         "id": "armswiki",
         "title": "To-do List",
-        "link": "https://armswiki.org/wiki/ARMS_Institute:To_Do"
+        "page": "ARMS_Institute:To_Do"
       },
       {
         "id": "bulbapedia",
         "title": "Contents",
-        "link": "https://bulbapedia.bulbagarden.net/wiki/Help:Contents"
+        "page": "Help:Contents"
       },
       {
         "id": "dragalialost",
         "title": "Contributor's Guide",
-        "link": "https://dragalialost.wiki/w/Contributor%27s_Guide"
+        "page": "Contributor%27s_Guide"
       },
       {
         "id": "dqwiki",
         "title": "Community Portal",
-        "link": "https://dragon-quest.org/wiki/Dragon_Quest_Wiki:Community_portal"
+        "page": "Dragon_Quest_Wiki:Community_portal"
       },
       {
         "id": "fewiki",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.fireemblemwiki.org/wiki/Fire_Emblem_Wiki:Cross-Wiki_Weekend"
+        "page": "Fire_Emblem_Wiki:Cross-Wiki_Weekend"
       },
       {
         "id": "fzerowiki",
         "title": "Cross-Wiki Guide",
-        "link": "https://mutecity.org/wiki/F-Zero_Wiki:Cross-Wiki_Weekend"
+        "page": "F-Zero_Wiki:Cross-Wiki_Weekend"
       },
       {
         "id": "gsuwiki",
         "title": "Contents",
-        "link": "https://goldensunwiki.net/wiki/Help:Contents"
+        "page": "Help:Contents"
       },
       {
         "id": "harddrop",
         "title": "Main Page",
-        "link": "https://harddrop.com/wiki/Tetris_Wiki"
+        "page": "Tetris_Wiki"
       },
       {
         "id": "icaruspedia",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.kidicaruswiki.org/wiki/Icaruspedia:Cross-Wiki_Weekend"
+        "page": "Icaruspedia:Cross-Wiki_Weekend"
       },
       {
         "id": "inkipedia",
         "title": "Cross-Wiki Guide",
-        "link": "https://splatoonwiki.org/wiki/Inkipedia:Cross-Wiki_Weekend"
+        "page": "Inkipedia:Cross-Wiki_Weekend"
       },
       {
         "id": "lylatwiki",
         "title": "Cross-Wiki Guide",
-        "link": "https://starfoxwiki.info/wiki/Lylat_Wiki:Cross-Wiki_Weekend"
+        "page": "Lylat_Wiki:Cross-Wiki_Weekend"
       },
       {
         "id": "metroidwiki",
         "title": "Maintenance",
-        "link": "https://www.metroidwiki.org/wiki/Metroid_Wiki:Maintenance"
+        "page": "Metroid_Wiki:Maintenance"
       },
       {
         "id": "nintendowiki",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.niwanetwork.org/wiki/NintendoWiki:Cross-Wiki_Weekend"
+        "page": "NintendoWiki:Cross-Wiki_Weekend"
       },
       {
         "id": "nookipedia",
         "title": "Cross-Wiki Guide",
-        "link": "https://nookipedia.com/wiki/Nookipedia:Cross-Wiki_Weekend"
+        "page": "Nookipedia:Cross-Wiki_Weekend"
       },
       {
         "id": "pikipedia",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.pikminwiki.com/Pikipedia:Cross-Wiki_Weekend"
+        "page": "Pikipedia:Cross-Wiki_Weekend"
       },
       {
         "id": "smashwiki",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.ssbwiki.com/SmashWiki:Cross-Wiki_Weekend"
+        "page": "SmashWiki:Cross-Wiki_Weekend"
       },
       {
         "id": "starfywiki",
         "title": "Community Portal",
-        "link": "https://www.starfywiki.org/wiki/Starfy_Wiki:Community_portal"
+        "page": "Starfy_Wiki:Community_portal"
       },
       {
         "id": "strategywiki",
         "title": "Community Portal",
-        "link": "https://strategywiki.org/wiki/StrategyWiki:Community_Portal"
+        "page": "StrategyWiki:Community_Portal"
       },
       {
         "id": "supermariowiki",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.mariowiki.com/MarioWiki:Cross-Wiki_Weekend"
+        "page": "MarioWiki:Cross-Wiki_Weekend"
       },
       {
         "id": "ukikipedia",
         "title": "To-do List",
-        "link": "https://ukikipedia.net/wiki/Ukikipedia:Todo"
+        "page": "Ukikipedia:Todo"
       },
       {
         "id": "warswiki",
         "title": "Main Page",
-        "link": "https://warswiki.org/wiki/Main_Page"
+        "page": "Main_Page"
       },
       {
         "id": "wikibound",
         "title": "Cross-Wiki Guide",
-        "link": "https://wikibound.info/wiki/WikiBound:Cross-Wiki_Weekend"
+        "page": "WikiBound:Cross-Wiki_Weekend"
       },
       {
         "id": "wikirby",
         "title": "Cross-Wiki Guide",
-        "link": "https://wikirby.com/wiki/WiKirby:Cross-Wiki_Weekend"
+        "page": "WiKirby:Cross-Wiki_Weekend"
       },
       {
         "id": "xenoserieswiki",
         "title": "Main Page",
-        "link": "https://www.xenoserieswiki.org/wiki/Main_Page"
+        "page": "Main_Page"
       },
       {
         "id": "zeldawiki",
         "title": "Cross-Wiki Guide",
-        "link": "https://zelda.fandom.com/wiki/Zelda_Wiki:Cross-Wiki_Weekend"
+        "page": "Zelda_Wiki:Cross-Wiki_Weekend"
       }
     ],
     "it": [
       {
         "id": "pokemoncentral",
         "title": "Cross-Wiki Guide",
-        "link": "https://wiki.pokemoncentral.it/Meta:Cross-Wiki_Weekend"
+        "page": "Meta:Cross-Wiki_Weekend"
       },
       {
         "id": "supermariowikiit",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.mariowiki.it/Super_Mario_Wiki:Cross-Wiki_Weekend"
+        "page": "Super_Mario_Wiki:Cross-Wiki_Weekend"
       },
       {
         "id": "wikiboundit",
         "title": "Main Page",
-        "link": "https://it.wikibound.info/wiki/Pagina_principale"
+        "page": "Pagina_principale"
       },
       {
         "id": "xenopediait",
         "title": "Cross-Wiki Guide",
-        "link": "https://www.xenopedia.it/Meta:Cross-Wiki_Weekend"
+        "page": "Meta:Cross-Wiki_Weekend"
       }
     ]
   }

--- a/data/cww.json
+++ b/data/cww.json
@@ -1,0 +1,153 @@
+{
+  "2021": {
+    "en": [
+      {
+        "id": "armswiki",
+        "title": "To-do List",
+        "link": "https://armswiki.org/wiki/ARMS_Institute:To_Do"
+      },
+      {
+        "id": "bulbapedia",
+        "title": "Contents",
+        "link": "https://bulbapedia.bulbagarden.net/wiki/Help:Contents"
+      },
+      {
+        "id": "dragalialost",
+        "title": "Contributor's Guide",
+        "link": "https://dragalialost.wiki/w/Contributor%27s_Guide"
+      },
+      {
+        "id": "dqwiki",
+        "title": "Community Portal",
+        "link": "https://dragon-quest.org/wiki/Dragon_Quest_Wiki:Community_portal"
+      },
+      {
+        "id": "fewiki",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.fireemblemwiki.org/wiki/Fire_Emblem_Wiki:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "fzerowiki",
+        "title": "Cross-Wiki Guide",
+        "link": "https://mutecity.org/wiki/F-Zero_Wiki:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "gsuwiki",
+        "title": "Contents",
+        "link": "https://goldensunwiki.net/wiki/Help:Contents"
+      },
+      {
+        "id": "harddrop",
+        "title": "Main Page",
+        "link": "https://harddrop.com/wiki/Tetris_Wiki"
+      },
+      {
+        "id": "icaruspedia",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.kidicaruswiki.org/wiki/Icaruspedia:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "inkipedia",
+        "title": "Cross-Wiki Guide",
+        "link": "https://splatoonwiki.org/wiki/Inkipedia:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "lylatwiki",
+        "title": "Cross-Wiki Guide",
+        "link": "https://starfoxwiki.info/wiki/Lylat_Wiki:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "metroidwiki",
+        "title": "Maintenance",
+        "link": "https://www.metroidwiki.org/wiki/Metroid_Wiki:Maintenance"
+      },
+      {
+        "id": "nintendowiki",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.niwanetwork.org/wiki/NintendoWiki:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "nookipedia",
+        "title": "Cross-Wiki Guide",
+        "link": "https://nookipedia.com/wiki/Nookipedia:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "pikipedia",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.pikminwiki.com/Pikipedia:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "smashwiki",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.ssbwiki.com/SmashWiki:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "starfywiki",
+        "title": "Community Portal",
+        "link": "https://www.starfywiki.org/wiki/Starfy_Wiki:Community_portal"
+      },
+      {
+        "id": "strategywiki",
+        "title": "Community Portal",
+        "link": "https://strategywiki.org/wiki/StrategyWiki:Community_Portal"
+      },
+      {
+        "id": "supermariowiki",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.mariowiki.com/MarioWiki:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "ukikipedia",
+        "title": "To-do List",
+        "link": "https://ukikipedia.net/wiki/Ukikipedia:Todo"
+      },
+      {
+        "id": "warswiki",
+        "title": "Main Page",
+        "link": "https://warswiki.org/wiki/Main_Page"
+      },
+      {
+        "id": "wikibound",
+        "title": "Cross-Wiki Guide",
+        "link": "https://wikibound.info/wiki/WikiBound:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "wikirby",
+        "title": "Cross-Wiki Guide",
+        "link": "https://wikirby.com/wiki/WiKirby:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "xenoserieswiki",
+        "title": "Main Page",
+        "link": "https://www.xenoserieswiki.org/wiki/Main_Page"
+      },
+      {
+        "id": "zeldawiki",
+        "title": "Cross-Wiki Guide",
+        "link": "https://zelda.fandom.com/wiki/Zelda_Wiki:Cross-Wiki_Weekend"
+      }
+    ],
+    "it": [
+      {
+        "id": "pokemoncentral",
+        "title": "Cross-Wiki Guide",
+        "link": "https://wiki.pokemoncentral.it/Meta:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "supermariowikiit",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.mariowiki.it/Super_Mario_Wiki:Cross-Wiki_Weekend"
+      },
+      {
+        "id": "wikiboundit",
+        "title": "Main Page",
+        "link": "https://it.wikibound.info/wiki/Pagina_principale"
+      },
+      {
+        "id": "xenopediait",
+        "title": "Cross-Wiki Guide",
+        "link": "https://www.xenopedia.it/Meta:Cross-Wiki_Weekend"
+      }
+    ]
+  }
+}

--- a/data/members.json
+++ b/data/members.json
@@ -1,6 +1,7 @@
 {
-  "en": {
-    "armswiki": {
+  "en": [
+    {
+      "id": "armswiki",
       "title": "ARMS Institute",
       "description": "ARMS Institute is a comprehensive resource for information about the Nintendo Switch game, ARMS. Founded on May 1, 2017 and growing rapidly, the wiki strives to offer in-depth coverage of ARMS from both a competitive and casual perspective. Join us and ARM yourself with knowledge!",
       "logo": "/images/logos/armswiki.png",
@@ -10,7 +11,8 @@
       "interwiki": "armswiki",
       "discord": "https://discord.gg/Mjt6A2m"
     },
-    "bulbapedia": {
+    {
+      "id": "bulbapedia",
       "title": "Bulbapedia",
       "description": "A part of the Bulbagarden community, Bulbapedia was founded on December 21, 2004 by Liam Pomfret. Everything you need to know about Pokémon can be found at Bulbapedia, whether about the games, the anime, the manga, or something else entirely. With its Bulbanews section and the Bulbagarden forums, it's your one-stop online place for Pokémon.",
       "logo": "/images/logos/bulbapedia.png",
@@ -25,7 +27,8 @@
       "facebook": "https://www.facebook.com/Bulbapedia",
       "discord": "https://discord.gg/bulbagarden"
     },
-    "dragalialost": {
+    {
+      "id": "dragalialost",
       "title": "Dragalia Lost Wiki",
       "description": "The Dragalia Lost Wiki was originally founded in September 2018 on the Gamepedia platform but went independent in January 2021. The Wiki aims to document anything and everything Dragalia Lost, from in-game data to mechanics, story, guides, and more!",
       "logo": "/images/logos/dragalialost.png",
@@ -36,7 +39,8 @@
       "twitter": "https://twitter.com/dragaliawiki",
       "discord": "https://discord.gg/dragalialost"
     },
-    "dqwiki": {
+    {
+      "id": "dqwiki",
       "title": "Dragon Quest Wiki",
       "description": "Originally founded on Wikia, the Dragon Quest Wiki was largely inactive until FlyingRagnar became an admin in late 2009. The wiki went independent about a year later when it merged with the Dragon Quest Dictionary/Encyclopedia which was run by Zenithian and supported by the Dragon's Den.  The Dragon Quest Wiki aims to be the most complete resource for Dragon Quest information on the web. It continues to grow in the hope that one day the series will be as popular in the rest of the world as it is in Japan.",
       "logo": "/images/logos/dragonquestwiki.png",
@@ -46,7 +50,8 @@
       "interwiki": "dragonquest",
       "forums": "https://www.woodus.com/forums/forum/88-dragon-quest-wiki/"
     },
-    "fewiki": {
+    {
+      "id": "fewiki",
       "title": "Fire Emblem Wiki",
       "description": "Growing since August 26, 2010, Fire Emblem Wiki is a relatively new project whose goal is to cover all information pertaining to the Fire Emblem series. Although it is still small, it aspires to become the most complete and accurate independent source of information on this series.",
       "logo": "/images/logos/fireemblemwiki.png",
@@ -59,7 +64,8 @@
       "facebook": "https://www.facebook.com/fireemblemwiki/",
       "discord": "https://discord.gg/FzRd5P4nyQ"
     },
-    "fzerowiki": {
+    {
+      "id": "fzerowiki",
       "title": "F-Zero Wiki",
       "description": "Founded on Wikia in November 2007, F-Zero Wiki became independent with NIWA's help in 2011. F-Zero Wiki is quickly growing into the Internet's definitive source for the world of 2200 km/h+, from pilots to machines, and is the founding part of MuteCity.org, the web's first major F-Zero community.",
       "logo": "/images/logos/fzerowiki.png",
@@ -72,7 +78,8 @@
       "facebook": "https://facebook.com/MuteCity.org",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "gsuwiki": {
+    {
+      "id": "gsuwiki",
       "title": "Golden Sun Universe",
       "description": "Originally founded on Wikia in late 2006, Golden Sun Universe has always worked hard to meet one particular goal: to be the single most comprehensive yet accessible resource on the Internet for Nintendo's RPG series Golden Sun. It became an independent wiki four years later. Covering characters and plot, documenting all aspects of the gameplay, featuring walkthroughs both thorough and bare-bones, and packed with all manner of odd and fascinating minutiae, Golden Sun Universe leaves no stone unturned!",
       "logo": "/images/logos/goldensununiverse.png",
@@ -81,7 +88,8 @@
       "mainpage": "Main_Page",
       "interwiki": "goldensun"
     },
-    "harddrop": {
+    {
+      "id": "harddrop",
       "title": "Hard Drop Tetris Wiki",
       "description": "The Tetris Wiki was founded by Tetris fans for Tetris fans on tetrisconcept.com in March 2006. The Tetris Wiki torch was passed to harddrop.com in July 2009. Hard Drop is a Tetris community for all Tetris players, regardless of skill or what version of Tetris you play.",
       "logo": "/images/logos/harddrop.png",
@@ -94,7 +102,8 @@
       "twitch": "https://www.twitch.tv/harddrop",
       "discord": "https://discord.gg/harddrop"
     },
-    "icaruspedia": {
+    {
+      "id": "icaruspedia",
       "title": "Icaruspedia",
       "description": "Icaruspedia is the Kid Icarus wiki that keeps flying to new heights. After going independent on January 8, 2012, Icaruspedia has worked to become the largest and most trusted independent source of Kid Icarus information. Just like Pit, they\"ll keep on fighting until the job is done.",
       "logo": "/images/logos/icaruspedia.png",
@@ -106,7 +115,8 @@
       "chat": "https://www.kidicaruswiki.org/wiki/Icaruspedia:Skype",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "inkipedia": {
+    {
+      "id": "inkipedia",
       "title": "Inkipedia",
       "description": "Inkipedia is your ever-growing go-to source for all things Splatoon related. Though founded on Wikia on June 10, 2014, Inkipedia went independent on May 18, 2015, just days before Splatoon's release. Our aim is to cover all aspects of the series, both high and low. Come splat with us now!",
       "logo": "/images/logos/inkipedia.png",
@@ -118,7 +128,8 @@
       "facebook": "https://www.facebook.com/Inkipedia",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "lylatwiki": {
+    {
+      "id": "lylatwiki",
       "title": "Lylat Wiki",
       "description": "Out of seemingly nowhere, Lylat Wiki sprung up one day in early 2010. Led by creator, Justin Folvarcik, and project head, Tacopill, the wiki has reached stability since the move to its own domain. The staff of Lylat Wiki are glad to help out the NIWA wikis and are even prouder to join NIWA's ranks as the source for information on the Star Fox series.",
       "logo": "/images/logos/lylatwiki.png",
@@ -131,7 +142,8 @@
       "facebook": "https://www.facebook.com/LylatWiki/",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "metroidwiki": {
+    {
+      "id": "metroidwiki",
       "title": "Metroid Wiki",
       "description": "Metroid Wiki, founded on January 27, 2010 by Nathanial Rumphol-Janc and Zelda Informer, is a rapidly expanding wiki that covers everything Metroid, from the games, to every suit, vehicle and weapon.",
       "logo": "/images/logos/metroidwiki.png",
@@ -144,7 +156,8 @@
       "facebook": "https://www.facebook.com/MetroidWiki",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "nintendowiki": {
+    {
+      "id": "nintendowiki",
       "title": "Nintendo Wiki",
       "description": "Created on May 12, 2010, NintendoWiki (N-Wiki) is a collaborative project by the NIWA team to create an encyclopedia dedicated to Nintendo, being the company around which all other NIWA content is focused. It ranges from mainstream information such as the games and people who work for the company, to the most obscure info like patents and interesting trivia.",
       "logo": "/images/logos/nintendowiki.png",
@@ -155,7 +168,8 @@
       "forums": "http://www.niwanetwork.org/forums/index.php?board=3.0",
       "discord": "https://discord.gg/59Mq6qB" 
     },
-    "nookipedia": {
+    {
+      "id": "nookipedia",
       "title": "Nookipedia",
       "description": "Founded in August 2005 on Wikia, Nookipedia was originally known as Animal Crossing City. Shortly after its five-year anniversary, Animal Crossing City decided to merge with the independent Animal Crossing Wiki, which in January 2011 was renamed to Nookipedia. Covering everything from the series including characters, items, critters, and much more, Nookipedia is your number one resource for everything Animal Crossing!",
       "logo": "/images/logos/nookipedia.png",
@@ -167,7 +181,8 @@
       "facebook": "https://www.facebook.com/nookipedia",
       "discord": "https://discord.gg/cpQ5tJV"
     },
-    "pikipedia": {
+    {
+      "id": "pikipedia",
       "title": "Pikipedia",
       "description": "Pikipedia, also known as Pikmin Wiki, was founded by Dark Lord Revan on Wikia in December 2005. In September 2010, with NIWA's help, Pikipedia moved away from Wikia to become independent. Pikipedia is working towards their goal of being the foremost source for everything Pikmin.",
       "logo": "/images/logos/pikipedia.png",
@@ -181,7 +196,8 @@
       "facebook": "https://www.facebook.com/Pikipedia",
       "discord": "https://discord.gg/msMKc3G"
     },
-    "pikifanon": {
+    {
+      "id": "pikifanon",
       "title": "Pikmin Fanon",
       "description": "Pikmin Fanon is a Pikmin wiki for fan stories (fanon). Founded back on November 1, 2008 by Rocky0718 as a part of Wikia, Pikmin Fanon has been independent since September 14, 2010. Check them out for fan created stories based around the Pikmin series.",
       "logo": "/images/logos/pikifanon.png",
@@ -192,7 +208,8 @@
       "forums": "https://www.pikminfanon.com/wiki/Forum:Index",
       "discord": "https://discord.gg/msMKc3G"
     },
-    "smashwiki": {
+    {
+      "id": "smashwiki",
       "title": "SmashWiki",
       "description": "Originally two separate wikis (one on SmashBoards, the other on Wikia), SmashWiki as we know it was formed out of a merge on February 29th, 2008, becoming independent on September 28th, 2010. SmashWiki is the premier source of Smash Bros. information, from simple tidbits to detailed mechanics, and also touches on the origins of its wealth of content from its sibling franchises.",
       "logo": "/images/logos/smashwiki.png",
@@ -204,7 +221,8 @@
       "discord": "https://discord.gg/wDR5jR2",
       "twitter": "https://twitter.com/SSBWikiOfficial"
     },
-    "starfywiki": {
+    {
+      "id": "starfywiki",
       "title": "Starfy Wiki",
       "description": "Founded on May 30, 2009, Starfy Wiki's one goal is to become the best source on Nintendo's elusive game series The Legendary Starfy. After gaining independence in 2011 with the help of Tappy and the wiki's original administrative team, the wiki still hopes to achieve its goal and be the best source of Starfy info for all present and future fans.",
       "logo": "/images/logos/starfywiki.png",
@@ -216,7 +234,8 @@
       "chat": "https://www.starfywiki.org/wiki/Starfy_Wiki:IRC",
       "twitter": "https://twitter.com/StarfyWiki"
     },
-    "strategywiki": {
+    {
+      "id": "strategywiki",
       "title": "StrategyWiki",
       "description": "StrategyWiki was founded in December 2005 by former member Brandon Suit with the idea that the existing strategy guides on the Internet could be improved. Three years later, in December 2008, Scott Jacobi officially established Abxy LLC for the purpose of owning and operating StrategyWiki as a community. Their vision is to bring free, collaborative video game strategy guides to the masses, including Nintendo franchise strategy guides.",
       "logo": "/images/logos/strategywiki.png",
@@ -228,7 +247,8 @@
       "facebook": "https://www.facebook.com/StrategyWiki",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "supermariowiki": {
+    {
+      "id": "supermariowiki",
       "title": "Super Mario Wiki",
       "description": "Online since August 12, 2005, when it was founded by Steve Shinn, Super Mario Wiki has you covered for anything Mario, Donkey Kong, Wario, Luigi, Yoshi—the whole gang, in fact. With its own large community in its accompanying forum, Super Mario Wiki is not only a great encyclopedia, but a fansite for you to talk anything Mario.",
       "logo": "/images/logos/mariowiki.png",
@@ -242,7 +262,8 @@
       "facebook": "https://www.facebook.com/smwiki",
       "discord": "https://discord.gg/w48g6zm"
     },
-    "ukikipedia": {
+    {
+      "id": "ukikipedia",
       "title": "Ukikipedia",
       "description": "Founded in 2018, Ukikipedia is a wiki focused on expert level knowledge of Super Mario 64, including detailed coverage of game mechanics, glitches, speedrunning, and challenges.",
       "logo": "/images/logos/ukikipedia.png",
@@ -253,7 +274,8 @@
       "twitter": "https://twitter.com/Ukikipedia",
       "discord": "https://discord.gg/YJcJ7Wq"
     },
-    "warswiki": {
+    {
+      "id": "warswiki",
       "title": "Wars Wiki",
       "description": "Created in February 2009, Wars Wiki is a small wiki community with a large heart. Founded by JoJo and Wars Central, Wars Wiki is going strong on one of Nintendo's lesser known franchises. Wars Wiki is keen to contribute to NIWA, and we're proud to be able to support them. With the Wars Central community, including forums, it's definitely worth checking out.",
       "logo": "/images/logos/warswiki.png",
@@ -263,7 +285,8 @@
       "interwiki": "warswiki",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "wikibound": {
+    {
+      "id": "wikibound",
       "title": "WikiBound",
       "description": "Founded in early 2010 by Tacopill, WikiBound strives to create a detailed database on the Mother/EarthBound games, a quaint series only having two games officially released outside of Japan. Help spread the PK Love by editing WikiBound!",
       "logo": "/images/logos/wikibound.png",
@@ -274,7 +297,8 @@
       "forums": "http://www.niwanetwork.org/forums/index.php?board=28.0",
       "discord": "https://discord.gg/pYghWh3"
     },
-    "wikirby": {
+    {
+      "id": "wikirby",
       "title": "WiKirby",
       "description": "WiKirby. It's a wiki. About Kirby! Amidst the excitement of NIWA being founded, Josh LeJeune decided to create a Kirby Wiki, due to lack of a strong independent one online. Coming online on Janury 24, 2010, WiKirby continues its strong launch with a dedicated community and a daily growing source of Kirby based knowledge.",
       "logo": "/images/logos/wikirby.png",
@@ -286,7 +310,8 @@
       "facebook": "https://facebook.com/wikirby",
       "discord": "https://discord.gg/4y9BPyj"
     },
-    "xenoserieswiki": {
+    {
+      "id": "xenoserieswiki",
       "title": "Xeno Series Wiki",
       "description": "Xeno Series Wiki was created February 4, 2020 by Sir Teatei Moonlight. While founded by the desire to have an independent wiki for Xenoblade, there was an interest in including the Xenogears and Xenosaga games within its focus as well. This wide range of coverage means it's always in need of new editors to help bolster its many subjects.",
       "logo": "/images/logos/xenoserieswiki.png",
@@ -297,7 +322,8 @@
       "discord": "https://discord.gg/F7nFZhr",
       "twitter": "https://twitter.com/XenoSeriesWiki"
     },
-    "zeldawiki": {
+    {
+      "id": "zeldawiki",
       "title": "Zelda Wiki",
       "description": "Founded on April 23, 2005 by Jason Rappaport, Zelda Wiki is your definitive source for encyclopedic information on The Legend of Zelda series, as well as all of the latest Zelda news. Not only that, but Zelda Wiki also provides exclusive articles found nowhere else. The site is now run by its own independent staff alongside the Zelda Universe webmasters.",
       "logo": "/images/logos/zeldawiki.png",
@@ -310,9 +336,10 @@
       "facebook": "https://www.facebook.com/zeldawiki",
       "discord": "https://discord.gg/eJnnvYb"
     }
-  },
-  "it": {
-    "pokemoncentral": {
+  ],
+  "it": [
+     {
+      "id": "pokemoncentral",
       "title": "Pokémon Central Wiki",
       "description": "Pokémon Central Wiki è un\"enciclopedia Pokémon in lingua italiana. È stata creata il 28 marzo 2008 da Gkx e Ipergorilla. Il 19 agosto 2010 è entrata a far parte del progetto Encyclopædiæ Pokémonis.",
       "logo": "/images/logos/pokemoncentral.png",
@@ -324,7 +351,8 @@
       "facebook": "https://www.facebook.com/pokemoncentral",
       "discord": "https://discord.gg/WX4RrRf"
     },
-    "supermariowikiit": {
+    {
+      "id": "supermariowikiit",
       "title": "Super Mario Wiki (IT)",
       "description": "La Super Mario Wiki è un\"enciclopedia su tutto ciò che riguarda la serie di Super Mario. È stata fondata il 30 novembre 2011 ed è affiliata con la Super Mario Wiki inglese e la Mario Wiki tedesca. Fa parte del Mario's Castle, primo sito italiano su Mario.",
       "logo": "/images/logos/mariowikiit.png",
@@ -335,7 +363,8 @@
       "facebook": "https://www.facebook.com/mariocastle.it",
       "discord": " https://discord.gg/jjncRZu"
     },
-    "wikiboundit": {
+    {
+      "id": "wikiboundit",
       "title": "Wikibound (IT)",
       "description": "WikiBound è il wiki italiano interamente dedicato alla serie di EarthBound/Mother. È stata fondata il 1° novembre 2018 e si è unita al circuito NiwiN il 26 gennaio.",
       "logo": "/images/logos/wikiboundit.png",
@@ -346,7 +375,8 @@
       "facebook": "https://www.facebook.com/WikiBoundITA",
       "discord": "https://discord.gg/7TqG99n"
     },
-    "xenopediait": {
+    {
+      "id": "xenopediait",
       "title": "Xenopedia (IT)",
       "description": "La Xenopedia è il primo wiki italiano completamente dedicato alla serie Xenoblade Chronicles, con qualche accenno alla serie Xeno in generale. È nata il 26 gennaio 2019 all\"interno del circuito NiwiN.",
       "logo": "/images/logos/xenopediait.png",
@@ -358,9 +388,10 @@
       "facebook": "https://www.facebook.com/XenobladeRAlpha",
       "discord": "https://discord.gg/A9vZCUP"
     }
-  },
-  "de": {
-    "mariowikide": {
+  ],
+  "de": [
+    {
+      "id": "mariowikide",
       "title": "MarioWiki",
       "description": "Das MarioWiki ist eine Enzyklopädie rund um alle Themen der äußerst berühmten, von Nintendo produzierten Mario-Serie, mit den wohl populärsten Videospielcharakteren aller Zeiten in der Hauptrolle.",
       "logo": "/images/logos/mariowikide.png",
@@ -369,12 +400,13 @@
       "forums": "https://mario-forum.net/",
       "facebook": "https://www.facebook.com/mariowiki.net"
     },
-    "zeldapendium": {
+    {
+      "id": "zeldapendium",
       "title": "Zeldapendium",
       "description": "Zeldapendium ist eine Enzyklopädie, also ein umfassendes Lexikon, die möglichst alle erhältlichen Informationen zu Nintendos Videospiel-Serie The Legend of Zelda sammeln und schön aufbereiten möchte. Unser Name setzt sich aus dem Namen des Spiels, Zelda, und dem ursprünglich lateinischen Wort für Nachschlagewerk, Compendium, zusammen. Wir verstehen uns als Mediaprojekt von Fans für Fans. Ins Leben gerufen wurde dieses Gemeinschaftsprojekt in Zusammenarbeit von Zeldafans, Zelda Kingdom und Zelda Europe.",
       "logo": "/images/logos/zeldapendium.png",
       "url": "https://www.zeldapendium.de/wiki/$1",
       "mainpage": "Zeldapendium:Hauptseite"
     }
-  }
+  ]
 }

--- a/style.css
+++ b/style.css
@@ -3,6 +3,8 @@ Desktop specific designs are found at the bottom */
 
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap');
 
+
+/* Element customizations */
 body {
   background: #f0f0f0 url("images/bg.png");
   font-family: "Open Sans", sans-serif;
@@ -22,7 +24,13 @@ ol {
   font-size: 0.938em;
 }
 
-/* Colors */
+a,
+a:visited {
+  color: #2f2f2f;
+  font-weight: normal;
+}
+
+/* Color classes */
 .white {
   color: white !important;
 }
@@ -48,15 +56,9 @@ ol {
 
 .main a,
 .main a:visited {
-  color: #2f2f2f;
+  color: #b22222;
   font-weight: bold;
   text-decoration: none;
-}
-
-a,
-a:visited {
-  color: #2f2f2f;
-  font-weight: normal;
 }
 
 .main a:hover {
@@ -463,6 +465,10 @@ a:visited {
 .member .description p {
   text-indent: 0;
   font-size: 0.875em;
+}
+
+.member a, .member a:visited {
+  color: #2f2f2f;
 }
 
 .member .links a:link {

--- a/style.css
+++ b/style.css
@@ -37,6 +37,9 @@ ol {
 .text-center {
   text-align: center;
 }
+.margin-auto {
+  margin: auto;
+}
 
 /* Main/content styling */
 .main li {
@@ -69,7 +72,6 @@ a:visited {
 #header {
   text-align: center;
 }
-
 #header a img {
   margin: 0 auto;
 }
@@ -89,7 +91,6 @@ a:visited {
   align-items: center;
   justify-content: space-between;
   transition: all 0.3s ease-out;
-
   overflow: hidden;
   max-height: 0;
 }
@@ -467,6 +468,15 @@ a:visited {
 .member .links a:link {
   margin: 0 5px 0 5px;
 }
+
+/* CWW pages */
+.cww-grid {
+  justify-content: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, calc(120px));
+  grid-gap: 1.5em 1em;
+}
+
 
 @-moz-document url-prefix() {
   .box .title {


### PR DESCRIPTION
Several big changes and additions with this PR (feedback is more than welcome):
* Our member and affiliate JSONs are now arrays of objects. Main reason for this is that these are lists of like objects, so logically it makes sense to have them as arrays. Secondary reason is that it allows us to more easily access each wiki's ID, which has been moved from being the name of each object into an `id` property (and greedily for this PR, I use the ID to connect data objects between `members.json` and the new `cww.json` file).
* Creation of a new `cww.json` data file for Cross-Wiki Weekend, to make it easier to maintain each wiki's guides. The object contains arrays by year that list all members that are participating in CWW that year, along with the title and link to each member's Cross-Wiki Weekend guide. So far this only has data for 2021, but I'd like to eventually backport for previous years. Example of an object:
```
      {
        "id": "nookipedia",
        "title": "Cross-Wiki Guide",
        "link": "https://nookipedia.com/wiki/Nookipedia:Cross-Wiki_Weekend"
      }
```
* Creation of the CWW 2021 page. Looks similar to last year, but with some improvements: the list of guides is now a responsive grid, and the list is generated from the new `cww.json` file.
* Links under the `.main` class are now red by default instead of black - to help distinguish bolded text from links.