### PR TITLE
Hard Drop Tetris Wiki name corrected

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -90,7 +90,7 @@
     },
     {
       "id": "harddrop",
-      "title": "Hard Drop Tetris Wiki",
+      "title": "Hard Drop - Tetris Wiki",
       "description": "The Tetris Wiki was founded by Tetris fans for Tetris fans on tetrisconcept.com in March 2006. The Tetris Wiki torch was passed to harddrop.com in July 2009. Hard Drop is a Tetris community for all Tetris players, regardless of skill or what version of Tetris you play.",
       "logo": "/images/logos/harddrop.png",
       "icon": "/images/icons/harddrop.jpg",


### PR DESCRIPTION
Hard Drop Tetris Wiki name corrected to Hard Drop - Tetris Wiki