### PR TITLE
Removing chat link from KHWiki, defunct

### DIFF
--- a/data/affiliates.json
+++ b/data/affiliates.json
@@ -45,7 +45,6 @@
     "logo": "/images/logos/khwiki.png",
     "url": "https://www.khwiki.com",
     "facebook": "https://www.facebook.com/khwikinet",
-    "chat": "https://www.khwiki.com/KHWiki:Chat",
     "twitter": "https://twitter.com/KHWiki",
     "discord": "https://discord.gg/bavMzKu"
   },


### PR DESCRIPTION
Kingdom Hearts Wiki has dropped IRC and now uses Discord for chat.