### PR TITLE
Adding CWW 2022 submission section

### DIFF
--- a/cross-wiki-week-2022.php
+++ b/cross-wiki-week-2022.php
@@ -79,12 +79,10 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         <a name="submit"></a>
         <h1 id="Submit">Submit Contributions</h1>
 
-        At the end of the event, please report your contributions by filling out the following form by <b>October<sup>th</sup></b>.
-        <br>
-        Filling out the form is required for a chance to win a prize!
+        At the end of the event, please report your contributions by filling out the following form by <b>October<sup>th</sup></b>. Filling out the form is required for a chance to win a prize!
         <br><br>
         <div style="width: 100%; text-align: center;">
-            <div class="button" style="background-color: #7F7F7F;"><span style="color: #3C3D3D;">Submission form opens in October</span></div>
+            <button class="button" disabled>Submission form opens in October</button>
         </div>
 
         <br>
@@ -231,7 +229,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         Una volta concluso l'evento, siete pregati di segnalare i vostri contributi compilando il seguente modulo entro il 7 ottobre. Compilare questo modulo è necessario per partecipare all'estrazione del premio. 
         <br><br>
         <div style="width: 100%; text-align: center;">
-            <div class="button" style="background-color: #7F7F7F;"><span style="color: #3C3D3D;">Submissions Open in October</span></div>
+            <button class="button" disabled>Submission form opens in October</button>
         </div>
 
         <br>

--- a/cross-wiki-week-2022.php
+++ b/cross-wiki-week-2022.php
@@ -79,7 +79,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         <a name="submit"></a>
         <h1 id="Submit">Submit Contributions</h1>
 
-        After the event ends, please report your contributions by filling out the following form by <b>October <sup>7th</sup></b>. Filling out the form is required for a chance to win a prize!
+        After the event ends, please report your contributions by filling out the following form by <b>October 7<sup>th</sup></b>. Filling out the form is required for a chance to win a prize!
         <br><br>
         <div style="width: 100%; text-align: center;">
             <button class="button" disabled>Submission form opens in October</button>

--- a/cross-wiki-week-2022.php
+++ b/cross-wiki-week-2022.php
@@ -79,7 +79,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         <a name="submit"></a>
         <h1 id="Submit">Submit Contributions</h1>
 
-        At the end of the event, please report your contributions by filling out the following form by <b>October<sup>th</sup></b>. Filling out the form is required for a chance to win a prize!
+        After the event ends, please report your contributions by filling out the following form by <b>October <sup>7th</sup></b>. Filling out the form is required for a chance to win a prize!
         <br><br>
         <div style="width: 100%; text-align: center;">
             <button class="button" disabled>Submission form opens in October</button>

--- a/cross-wiki-week-2022.php
+++ b/cross-wiki-week-2022.php
@@ -73,6 +73,19 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             <li>Each wiki is a bit different! Become familiar with the differing guidelines, styling, and policies of each wiki. Reach out to each wiki's help resources if you have any questions.</li>
             <li>At the end of the event, fill out and submit the participation form by <b>October 7<sup>th</sup></b> for a chance to win the prize. Even if you don't want the prize, we appreciate you filling the form out for statistical purposes.</li>
         </ul>
+        
+        <br>
+
+        <a name="submit"></a>
+        <h1 id="Submit">Submit Contributions</h1>
+
+        At the end of the event, please report your contributions by filling out the following form by <b>October<sup>th</sup></b>.
+        <br>
+        Filling out the form is required for a chance to win a prize!
+        <br><br>
+        <div style="width: 100%; text-align: center;">
+            <div class="button" style="background-color: #7F7F7F;"><span style="color: #3C3D3D;">Submission form opens in October</span></div>
+        </div>
 
         <br>
 
@@ -210,6 +223,16 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             <li>Ciascun wiki &#232; leggermente differente! Prima di apportare modifiche, familiarizzate con le linee guida, i manuali di stile e le pratiche adottate da ciascun wiki. Per qualsiasi domanda, consultate le pagine di aiuto dei rispettivi wiki.</li>
             <li>Alla fine dell'evento, compilate e inviate il modulo di partecipazione sottostante entro il <b>7 ottobre</b> per avere una possibilit&#224; di vincere il premio. Anche se non doveste volere il premio, apprezzeremmo se compilaste il modulo per fini statistici.</li>
         </ul>
+
+        <br>
+        
+        <h1 id="Submit">Modulo</h1>
+
+        Una volta concluso l'evento, siete pregati di segnalare i vostri contributi compilando il seguente modulo entro il 7 ottobre. Compilare questo modulo è necessario per partecipare all'estrazione del premio. 
+        <br><br>
+        <div style="width: 100%; text-align: center;">
+            <div class="button" style="background-color: #7F7F7F;"><span style="color: #3C3D3D;">Submissions Open in October</span></div>
+        </div>
 
         <br>
 

--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@ a:visited {
   font-weight: normal;
 }
 
-.button {
+button, .button {
   color: white;
   background-color: #b22222;
   border: none;
@@ -39,9 +39,18 @@ a:visited {
   max-width: 200px;
   text-align: center;
 }
-.button:hover {
+button:hover, .button:hover {
   background-color: #961616;
 }
+button[disabled] {
+  color: black;
+  background-color: #e9e9e9;
+  border: 1px #cecece solid;
+}
+button[disabled]:hover {
+  background-color: #e9e9e9;
+}
+
 
 /* Color classes */
 .white {


### PR DESCRIPTION
Adding a submission section to the CWW 2022 page. While the form isn't yet available, it'll let participants know where to look when the form opens in October.

English:
<img width="662" alt="A screenshot showing the form submission section in English" src="https://user-images.githubusercontent.com/7636606/192117504-83aaabd0-59e3-48c3-8a43-fecd9300dd97.png">


Italian:
<img width="656" alt="A screenshot showing the form submission section in Italian" src="https://user-images.githubusercontent.com/7636606/192117055-2273ca10-c2dd-4ef9-b497-411725a689bb.png">
