### PR TITLE
Revert Zeldapedia interwiki change

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -329,7 +329,6 @@
       "url": "https://zeldapedia.wiki/wiki/$1",
       "mainpage": "Main_Page",
       "interwiki": "zeldawiki",
-      "forums": "https://zeldauniverse.net/forums/Board/191-Zelda-Wiki/",
       "twitter": "https://twitter.com/zeldawiki",
       "facebook": "https://www.facebook.com/zeldawiki",
       "discord": "https://discord.gg/eJnnvYb"

--- a/data/members.json
+++ b/data/members.json
@@ -328,7 +328,7 @@
       "icon": "/images/icons/zeldapedia.png",
       "url": "https://zeldapedia.wiki/wiki/$1",
       "mainpage": "Main_Page",
-      "interwiki": "zeldapedia",
+      "interwiki": "zeldawiki",
       "forums": "https://zeldauniverse.net/forums/Board/191-Zelda-Wiki/",
       "twitter": "https://twitter.com/zeldawiki",
       "facebook": "https://www.facebook.com/zeldawiki",


### PR DESCRIPTION
Switch recommended interwiki back to zeldawiki, it's an unnecessary change.