### PR TITLE
Removing Dragon Quest Wiki (expelled) / Updating getMemberWikis endpoint

### DIFF
--- a/_api.php
+++ b/_api.php
@@ -51,10 +51,26 @@ class NiwaDataHelper
 	 */
 	public function getMemberWikis($languageCode = null)
 	{
+		$filteredMembers = [];
+
 		if ($languageCode) {
-			return $this->memberWikis->{$languageCode};
+			$filteredMembers = array_filter(
+				$this->memberWikis->{$languageCode}, 
+				function($val){ 
+					return !($val->former ?? false);
+				});
+		} else {
+			foreach ($this->memberWikis as $key => $data) {
+				$filteredMembers = array_merge($filteredMembers, $this->memberWikis->{$key});
+			}
+			$filteredMembers = array_filter(
+				$filteredMembers, 
+				function($val){ 
+					return !($val->former ?? false);
+				});
 		}
-		return $this->memberWikis;
+
+		return $filteredMembers;
 	}
 
 	/**

--- a/data/members.json
+++ b/data/members.json
@@ -48,7 +48,8 @@
       "url": "https://dragon-quest.org/wiki/$1",
       "mainpage": "Main_Page",
       "interwiki": "dragonquest",
-      "forums": "https://www.woodus.com/forums/forum/88-dragon-quest-wiki/"
+      "forums": "https://www.woodus.com/forums/forum/88-dragon-quest-wiki/",
+      "former": true
     },
     {
       "id": "fewiki",


### PR DESCRIPTION
* Dragon Quest Wiki has withdrawn + expelled from the alliance per a vote.
* Added new `former` attribute to DQWiki in `members.json` to account for former members.
  * While we could remove DQWiki's entry entirely, the historical Cross-Wiki Week event pages will break as they use `members.json` to display each participating wiki's logo, title, and URL. We may change this in the future so CWW data is completely independent of `members.json`.
* Updated `getMemberWikis`:
  * Filters out members with `former` attribute set to `true`.
  * If no language code is provided, the function now returns a flat array of all members.
