### PR TITLE
Creating new redirect service + fixing getMemberWikis() function

### DIFF
--- a/_api.php
+++ b/_api.php
@@ -56,6 +56,7 @@ class NiwaDataHelper
 		$filteredMembers = [];
 
 		if ($languageCode) {
+			// If specific language is requested...
 			if($includeFormer) {
 				$filteredMembers = $this->memberWikis->{$languageCode};
 			} else {
@@ -66,14 +67,19 @@ class NiwaDataHelper
 				});
 			}
 		} else {
-			foreach ($this->memberWikis as $key => $data) {
-				$filteredMembers = array_merge($filteredMembers, $this->memberWikis->{$key});
+			// If all languages are requested...
+
+			// Merge language arrays:
+			$allMemberWikis = [];
+			foreach ($this->memberWikis as $memberWikis) {
+				$allMemberWikis = array_merge($allMemberWikis, $memberWikis);
 			}
-			if($includeFormer) {
-				$filteredMembers = $this->memberWikis->{$languageCode};
+			
+			if ($includeFormer) {
+				$filteredMembers = $allMemberWikis;
 			} else {
 				$filteredMembers = array_filter(
-				$this->memberWikis->{$languageCode}, 
+				$allMemberWikis, 
 				function($val){ 
 					return !($val->former ?? FALSE);
 				});

--- a/go.php
+++ b/go.php
@@ -1,0 +1,68 @@
+<?php
+    $title = 'Redirect Service';
+    include('_header.php');
+
+    $dataHelper = new NiwaDataHelper();
+    $wikis = $dataHelper->getMemberWikis();
+
+    $url = $_SERVER['REQUEST_URI'];
+    $urlParts = parse_url($url);
+    $path = $urlParts['path'];
+    $pathSegments = explode('/', $path);
+
+    if (count($pathSegments) > 2) {
+        $site = $pathSegments[2] ?? null;
+        $article = implode('/', array_slice($pathSegments, 3)) ?? null;
+        $target = null;
+
+        foreach ($wikis as $wiki) {
+            if ($wiki->id === $site) {
+                $target = $wiki->url;
+                $target = str_replace('$1', $article, $target);
+            }
+        }
+
+        if ($target) {
+            header("Location: {$target}");
+            exit();
+        }
+    }
+?>
+
+<div class="main">
+    <h1>NIWA Redirect Service</h1>
+    
+    This URL serves as a gateway to link to any article on any NIWA member wiki.
+
+    <br /><br />
+
+    URL format: <code>https://niwanetwork.org/go/{site}/{article}</code>
+
+    <br /><br />
+
+    Replace <code>{site}</code> with the site ID from the table below, and <code>{article}</code> with your desired article name.
+
+    <br /><br />
+
+    <table>
+        <tr>
+            <th>Site ID</th>
+            <th>Site URL</th>
+        </tr>
+        <?php
+            foreach ($wikis as $wiki) {
+                echo "
+                <tr>
+                    <td>{$wiki->id}</td>
+                    <td>{$wiki->url}</td>
+                </tr>
+                ";
+            }
+        ?>
+    </table>
+</div>
+
+<?php
+    include('_sidebar.php');
+    include('_footer.php');
+?>

--- a/style.css
+++ b/style.css
@@ -52,6 +52,18 @@ button[disabled]:hover {
   cursor: not-allowed;
 }
 
+table { 
+  border-collapse: collapse; 
+} 
+th {
+  background-color: #e9e9e9;
+}
+th, td { 
+  padding: 8px; 
+} 
+tr:nth-child(odd) { 
+  background-color: #ededed; 
+} 
 
 /* Color classes */
 .white {


### PR DESCRIPTION
This PR introduces a new `/go` page that serves as a redirect gateway to any member NIWA wiki.

URL format: `https://niwanetwork.org/go/{site}/{article}`

Example: `https://niwanetwork.org/go/nookipedia/Tom_Nook`

See screenshot:
<img width="600" alt="Screenshot of the new redirect gateway" src="https://github.com/niwanetwork/niwa-website/assets/7636606/f082bc27-ce84-4e5f-bef5-69377eeb1b87">

The main driver for this is the [proposed NIWA article ID property](https://www.wikidata.org/wiki/Wikidata:Property_proposal/NIWA_article_ID) on Wikidata, which requires a central redirection service.

While we could technically use Nintendo Wiki's interwiki links, I'm proposing this system at the top-level site for a few reasons:
* Provides a more user-friendly explanation for how the service works
* Automatically updates when we add new members
* Nintendo Wiki is its own wiki that can manage its interwiki links however it wants (including removing, renaming, etc.); by having a separate redirection service at the org level, we can ensure links stay consistent and meet org-level needs
  * To that point, Nintendo Wiki has multiple interwiki links for some wikis -- which can be fine for Nintendo Wiki's purposes, but is a point of concern in the Wikidata discussion.

----

This PR also fixes the `getMemberWiki` function when no language is provided.