### PR TITLE
Update social data for Pokémon Central Wiki

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -443,8 +443,6 @@
       "chat": "https://telegram.me/pcentralchat",
       "instagram": "https://www.instagram.com/pokemoncentral_official",
       "twitter": "https://twitter.com/pokemoncentral",
-      "facebook": "https://www.facebook.com/pokemoncentral",
-      "discord": "https://discord.gg/WX4RrRf",
       "telegram": "https://telegram.me/pokemoncentral",
       "youtube": "https://www.youtube.com/pokemoncentralvideo"
     },


### PR DESCRIPTION
removing fb and discord from pcw social