### PR TITLE
Updating Nookipedia description

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -240,7 +240,7 @@
     {
       "id": "nookipedia",
       "title": "Nookipedia",
-      "description": "Founded in August 2005 on Wikia, Nookipedia was originally known as Animal Crossing City. Shortly after its five-year anniversary, Animal Crossing City decided to merge with the independent Animal Crossing Wiki, which in January 2011 was renamed to Nookipedia. Covering everything from the series including characters, items, critters, and much more, Nookipedia is your number one resource for everything Animal Crossing!",
+      "description": "Founded on October 23, 2010, Nookipedia joined NIWA shortly afterward thanks to Animal Crossing City, which forked from Wikia and merged its contents into Nookipedia in November 2010. Covering everything from the series including characters, items, critters, and much more, Nookipedia is your number one resource for everything Animal Crossing!",
       "logo": "/images/logos/nookipedia.png",
       "url": "https://nookipedia.com/wiki/$1",
       "mainpage": "Main_Page",


### PR DESCRIPTION
Clarifying that Nookipedia was an independent wiki before the merger and was not created as a part of it.